### PR TITLE
Lazy load docker

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,11 +1,9 @@
-var Docker = require('dockerode');
 var async = require('async');
+var docker = require('./lazy-docker');
 var fnpm = require('fstream-npm');
 var path = require('path');
 var tar = require('tar');
 var through = require('through');
-
-var docker = new Docker();
 
 exports.simple = simpleExec;
 exports.streamIn = streamInExec;
@@ -57,7 +55,7 @@ function streamInExec(container, cmd, callback) {
 }
 
 function captureExec(stream, next) {
-  docker.modem.demuxStream(stream, through(dot), process.stdout);
+  docker().modem.demuxStream(stream, through(dot), process.stdout);
   stream.on('end', function() {
     if (dot.written) {
       console.log('done');

--- a/lib/image.js
+++ b/lib/image.js
@@ -1,8 +1,6 @@
-var Docker = require('dockerode');
 var async = require('async');
+var docker = require('./lazy-docker');
 var through = require('through');
-
-var docker = new Docker();
 
 exports.singleLayer = singleLayerImage;
 exports.copy = copyFromContainerImage;
@@ -33,7 +31,7 @@ function singleLayerImage(img, cmd, callback) {
   });
 
   function create(next) {
-    docker.createContainer(containerConfig, next);
+    docker().createContainer(containerConfig, next);
   }
 
   function start(newContainer, next) {
@@ -108,7 +106,7 @@ function copyFromContainerImage(srcContainer, srcPaths, baseImage, callback) {
   }
 
   function createTarX(next) {
-    docker.createContainer(tarx, next);
+    docker().createContainer(tarx, next);
   }
 
   function attachTarX(c, next) {
@@ -123,7 +121,7 @@ function copyFromContainerImage(srcContainer, srcPaths, baseImage, callback) {
   }
 
   function startTarX(stream, next) {
-    docker.modem.demuxStream(stream, fileCounter, process.stdout);
+    docker().modem.demuxStream(stream, fileCounter, process.stdout);
     tarPipe.pipe(stream.req);
     destContainer.start(tarx, next);
   }
@@ -137,7 +135,7 @@ function copyFromContainerImage(srcContainer, srcPaths, baseImage, callback) {
   }
 
   function captureTarC(stream, next) {
-    docker.modem.demuxStream(stream, tarPipe, process.stdout);
+    docker().modem.demuxStream(stream, tarPipe, process.stdout);
     stream.on('end', function() {
       tarPipe.end();
     });
@@ -168,7 +166,7 @@ function startImage(baseImage, env, callback) {
       Cmd: ['sleep', '1000'],
       Env: env,
     };
-    docker.createContainer(opts, next);
+    docker().createContainer(opts, next);
   }
 
   function start(c, next) {

--- a/lib/lazy-docker.js
+++ b/lib/lazy-docker.js
@@ -1,0 +1,6 @@
+var Docker = require('dockerode');
+var lodash = require('lodash');
+
+module.exports = lodash.memoize(function() {
+  return new Docker();
+});

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   },
   "homepage": "https://github.com/strongloop/strong-docker-build",
   "devDependencies": {
-    "eslint": "^0.18.0",
+    "eslint": "^0.22.1",
     "jscs": "^1.12.0",
-    "tap": "^0.7.1"
+    "tap": "^1.2.0"
   },
   "dependencies": {
-    "async": "^0.9.0",
+    "async": "^1.2.1",
     "dockerode": "^2.1.1",
     "fstream-npm": "^1.0.2",
     "lodash": "^3.9.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "async": "^0.9.0",
     "dockerode": "^2.1.1",
     "fstream-npm": "^1.0.2",
+    "lodash": "^3.9.3",
     "tar": "^2.0.0",
     "through": "^2.3.7"
   }

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -1,16 +1,15 @@
 var builder = require('../');
-var Docker = require('dockerode');
+var docker = require('../lib/lazy-docker');
 var path = require('path');
 var tap = require('tap');
 
 var appRoot = path.resolve(__dirname, 'sample-app');
-var docker = new Docker();
 var builtImage = null;
 
 tap.test('node base image', {timeout: 90000}, function(t) {
-  docker.pull('node:0.10', {repo: 'node'}, function(err, stream) {
+  docker().pull('node:0.10', {repo: 'node'}, function(err, stream) {
     t.ifError(err, 'start pull node:latest without error');
-    docker.modem.followProgress(stream, function(err) {
+    docker().modem.followProgress(stream, function(err) {
       t.ifError(err, 'pull node:latest without error');
       t.end();
     });
@@ -18,9 +17,9 @@ tap.test('node base image', {timeout: 90000}, function(t) {
 });
 
 tap.test('debian:jessie base image', {timeout: 90000}, function(t) {
-  docker.pull('debian:jessie', {repo: 'debian'}, function(err, stream) {
+  docker().pull('debian:jessie', {repo: 'debian'}, function(err, stream) {
     t.ifError(err, 'start pull debian:jessie without error');
-    docker.modem.followProgress(stream, function(err) {
+    docker().modem.followProgress(stream, function(err) {
       t.ifError(err, 'finish pull debian:jessie without error');
       t.end();
     });
@@ -28,7 +27,7 @@ tap.test('debian:jessie base image', {timeout: 90000}, function(t) {
 });
 
 tap.test('remove existing default', function(t) {
-  var img = docker.getImage('sl-docker-run/test-app:0.0.0');
+  var img = docker().getImage('sl-docker-run/test-app:0.0.0');
   img.remove({force: true}, function() {
     t.ok(true, 'removed existing image if existed');
     t.end();
@@ -49,7 +48,8 @@ tap.test('wait for default image', function(t) {
 });
 
 tap.test('inspect image', function(t) {
-  docker.getImage('sl-docker-run/test-app:0.0.0').inspect(function(err, image) {
+  docker().getImage('sl-docker-run/test-app:0.0.0')
+          .inspect(function(err, image) {
     t.ifError(err, 'Image should be inspectable');
     builtImage = image;
     var cfg = image.Config;
@@ -63,7 +63,8 @@ tap.test('inspect image', function(t) {
 });
 
 tap.test('remove existing custom image', function(t) {
-  docker.getImage('strong-docker-build:test').remove({force: true}, function() {
+  docker().getImage('strong-docker-build:test')
+          .remove({force: true}, function() {
     t.ok(true, 'removed existing image if existed');
     t.end();
   });
@@ -84,7 +85,7 @@ tap.test('wait for  custom image', function(t) {
 });
 
 tap.test('inspect rebuilt image', function(t) {
-  docker.getImage('strong-docker-build:test').inspect(function(err, image) {
+  docker().getImage('strong-docker-build:test').inspect(function(err, image) {
     t.ifError(err, 'Rebuild image should be inspectable');
     t.ok(image.VirtualSize * 0.99999 < builtImage.VirtualSize &&
          image.VirtualSize * 1.00001 > builtImage.VirtualSize,


### PR DESCRIPTION
This is partially a work around for a problem fixed in apocas/docker-modem#44, but also a correction in behaviour since it should not be constructing the `Docker` instance until it is actually needed anyway.

/cc @altsang 